### PR TITLE
set amounts to u64 not u8

### DIFF
--- a/file.rs
+++ b/file.rs
@@ -5,7 +5,7 @@ use anchor_lang::prelude::*;
 pub struct Lending {
   pub lender: Pubkey,
   pub borrower: Pubkey,
-  pub amount: u8, //@note :: dummy flaw that will be fixed by deeydos via PR to u64
+  pub amount: u64, //@note :: dummy flaw that will be fixed by deeydos via PR to u64
   pub interest_bps: u16,
   pub borrowed_date: i64,
   pub grace_period: i64,


### PR DESCRIPTION
lending::amount is incorrectly using u8 which limits borrowing upto 255 wei, make sure to use u64 

```diff
- pub amounts: u8,
+ pub amounts: u64,